### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Cpptmembership/Form/Settings.php
+++ b/CRM/Cpptmembership/Form/Settings.php
@@ -42,7 +42,7 @@ class CRM_Cpptmembership_Form_Settings extends CRM_Core_Form {
               $setting['name'],
               // field label
               $setting['title'],
-              $this->getSettingOptions($setting), NULL, CRM_Utils_Array::value('html_attributes', $setting)
+              $this->getSettingOptions($setting), NULL, $setting['html_attributes'] ?? []
             );
             break;
 
@@ -121,7 +121,7 @@ class CRM_Cpptmembership_Form_Settings extends CRM_Core_Form {
    */
   public function validate() {
     $error = parent::validate();
-    $submittedMonthDay = CRM_Utils_Array::value('cpptmembership_cutoffMonthDayEnglish', $this->_submitValues);
+    $submittedMonthDay = $this->_submitValues['cpptmembership_cutoffMonthDayEnglish'] ?? NULL;
     $formattedMonthDay = date('m-d', strtotime("2001-{$submittedMonthDay}"));
     if ($submittedMonthDay != $formattedMonthDay) {
       $this->setElementError('cpptmembership_cutoffMonthDayEnglish', E::ts('"Payment cut-off month and day" must be in the format MM-DD.'));
@@ -211,7 +211,7 @@ class CRM_Cpptmembership_Form_Settings extends CRM_Core_Form {
         'return' => array_keys($this->_settings),
         'sequential' => 1,
       ));
-      $ret = CRM_Utils_Array::value(0, $result['values']);
+      $ret = $result['values'][0] ?? NULL;
     }
     return $ret;
   }
@@ -268,7 +268,7 @@ class CRM_Cpptmembership_Form_Settings extends CRM_Core_Form {
   private function _verifySettingsOnFormLoad() {
     if (!$this->_flagSubmitted) {
       $defaults = $this->setDefaultValues();
-      if ($contributionPageId = CRM_Utils_Array::value('cpptmembership_cpptContributionPageId', $defaults)) {
+      if ($contributionPageId = $defaults['cpptmembership_cpptContributionPageId'] ?? NULL) {
         $warnings = CRM_Cpptmembership_Utils::getContributionPageConfigWarnings($contributionPageId);
         foreach ($warnings as $warning) {
           CRM_Core_Session::setStatus($warning, NULL, NULL, ['expires' => 0]);
@@ -278,7 +278,7 @@ class CRM_Cpptmembership_Form_Settings extends CRM_Core_Form {
   }
 
   private function _validatePriceField($priceFieldSettingName) {
-    $priceFieldId = CRM_Utils_Array::value($priceFieldSettingName, $this->_submitValues);
+    $priceFieldId = $this->_submitValues[$priceFieldSettingName] ?? NULL;
     if (empty($priceFieldId)) {
       return;
     }
@@ -288,8 +288,8 @@ class CRM_Cpptmembership_Form_Settings extends CRM_Core_Form {
       'id' => $priceFieldId,
     ]);
     if ($priceSetField['count']) {
-      $priceSetId = CRM_Utils_Array::value('price_set_id', $priceSetField['values'][0]);
-      $submittedContributionPageId = CRM_Utils_Array::value('cpptmembership_cpptContributionPageId', $this->_submitValues);
+      $priceSetId = $priceSetField['values'][0]['price_set_id'] ?? NULL;
+      $submittedContributionPageId = $this->_submitValues['cpptmembership_cpptContributionPageId'] ?? NULL;
       $query = "SELECT * FROM civicrm_price_set_entity WHERE entity_table = 'civicrm_contribution_page' AND entity_id = %1 AND price_set_id = %2";
       $queryParams = [
         '1' => [$submittedContributionPageId, 'Int'],

--- a/CRM/Cpptmembership/Utils.php
+++ b/CRM/Cpptmembership/Utils.php
@@ -129,7 +129,7 @@ AND cc.sort_name LIKE '%$name%'";
         ]);
         $hasPriceField = FALSE;
         if ($priceSetField['count']) {
-          $priceSetId = CRM_Utils_Array::value('price_set_id', $priceSetField['values'][0]);
+          $priceSetId = $priceSetField['values'][0]['price_set_id'] ?? NULL;
           $query = "SELECT * FROM civicrm_price_set_entity WHERE entity_table = 'civicrm_contribution_page' AND entity_id = %1 AND price_set_id = %2";
           $queryParams = [
             '1' => [$contributionPageId, 'Int'],
@@ -157,7 +157,7 @@ AND cc.sort_name LIKE '%$name%'";
         ]);
         $hasPriceField = FALSE;
         if ($priceSetField['count']) {
-          $priceSetId = CRM_Utils_Array::value('price_set_id', $priceSetField['values'][0]);
+          $priceSetId = $priceSetField['values'][0]['price_set_id'] ?? NULL;
           $query = "SELECT * FROM civicrm_price_set_entity WHERE entity_table = 'civicrm_contribution_page' AND entity_id = %1 AND price_set_id = %2";
           $queryParams = [
             '1' => [$contributionPageId, 'Int'],
@@ -392,7 +392,7 @@ AND cc.sort_name LIKE '%$name%'";
     foreach ($membershipPayment['values'] as $value) {
       $endDateTime = strtotime(CRM_Utils_Array::value('membership_id.end_date', $value));
       if (!$checkEndDate || $endDateTime == $lastDayOfThisYearTime) {
-        $membershipIdsToFix[] = CRM_Utils_Array::value('membership_id', $value);
+        $membershipIdsToFix[] = $value['membership_id'] ?? NULL;
       }
     }
     if (!empty($membershipIdsToFix)) {

--- a/cpptmembership.php
+++ b/cpptmembership.php
@@ -23,7 +23,7 @@ function cpptmembership_civicrm_post($op, $objectName, $objectId, &$objectRef) {
     // Don't botHer unless there's a contribution_page_id, and the related
     // contribution page is our configured CPPT page.
     if (
-      ($contributionPageId = CRM_Utils_Array::value('contribution_page_id', $contribution))
+      ($contributionPageId = $contribution['contribution_page_id'] ?? NULL)
       && ($contributionPageId == _cpptmembership_getSetting('cpptmembership_cpptContributionPageId'))
     ) {
       CRM_Cpptmembership_Utils::correctMembershipDatesForCpptContribution($contribution, TRUE);
@@ -51,7 +51,7 @@ function cpptmembership_civicrm_pre($op, $objectName, $id, &$params) {
         $params['status_id'] = $statusId;
       }
       // Force member start date to member since, if available
-      $params['start_date'] = CRM_Utils_Array::value('join_date', $params, CRM_Utils_Array::value('join_date', $membership));
+      $params['start_date'] = $params['join_date'] ?? $membership['join_date'] ?? NULL;
     }
   }
 }
@@ -205,14 +205,14 @@ function cpptmembership_civicrm_buildForm($formName, &$form) {
           'class' => "cppt-member cppt-member-org-{$orgId}",
         ];
         $noteMarker = '';
-        if (CRM_Utils_Array::value('hasCompletedCurrentPayment', $membership)) {
+        if (!empty($membership['hasCompletedCurrentPayment'])) {
           $noteMarker = ' *';
           $attributes['disabled'] = 'disabled';
         }
-        elseif (CRM_Utils_Array::value('hasPendingCurrentPayment', $membership)) {
+        elseif (!empty($membership['hasPendingCurrentPayment'])) {
           $noteMarker = ' &dagger;';
         }
-        elseif (CRM_Utils_Array::value('paymentNeedsResolution', $membership)) {
+        elseif (!empty($membership['paymentNeedsResolution'])) {
           $noteMarker = ' &Dagger;';
           $attributes['disabled'] = 'disabled';
         }
@@ -468,7 +468,7 @@ function _cpptmembership_getSetting($settingName) {
 
 function _cpptmembership_getPaidMembershipsFromFormValues($formValues) {
   $paidMemberships = [];
-  if ($orgId = CRM_Utils_Array::value('cppt_organization', $formValues)) {
+  if ($orgId = $formValues['cppt_organization'] ?? NULL) {
     $mids = CRM_Utils_Array::value('cppt_mid', $formValues, []);
     foreach (array_keys($mids) as $mid) {
       list($mid_orgId, $mid_membershipId) = explode('_', $mid);
@@ -503,7 +503,7 @@ function _cpptmembership_getCpptPrice($billingPolicy = CPPTMEMBERSHIP_BILLING_PO
       $priceFieldValue = civicrm_api3('priceFieldValue', 'getSingle', [
         'price_field_id' => $priceFieldId,
       ]);
-      $amount = CRM_Utils_Array::value('amount', $priceFieldValue);
+      $amount = $priceFieldValue['amount'] ?? NULL;
     }
   }
   return $amount;


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.